### PR TITLE
Move computer use capabilities from create-kernel-app to dedicated TypeScript SDK

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "semi": ["error", "always"],
+    "quotes": ["error", "single"],
+    "indent": ["error", 2],
+    "comma-trailing": "off",
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
+  "ignorePatterns": [
+    "dist/",
+    "node_modules/"
+  ]
+} 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Dependencies
+node_modules/
+package-lock.json
+
+# TypeScript
+*.tsbuildinfo
+dist/
+build/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Testing
+coverage/
+.nyc_output/
+
+# Misc
+.cache/
+.temp/
+.tmp/ 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ A TypeScript SDK that combines Anthropic's Computer Use capabilities with Playwr
 ## Installation
 
 ```bash
-npm install cu-playwright-ts
+npm install @onkernel/cu-playwright-ts
 # or
-yarn add cu-playwright-ts
+yarn add @onkernel/cu-playwright-ts
 # or
-bun add cu-playwright-ts
+bun add @onkernel/cu-playwright-ts
 ```
 
 ## Quick Start
 
 ```typescript
 import { chromium } from 'playwright';
-import { ComputerUseAgent } from 'cu-playwright-ts';
+import { ComputerUseAgent } from '@onkernel/cu-playwright-ts';
 
 const browser = await chromium.launch({ headless: false });
 const page = await browser.newPage();
@@ -100,7 +100,7 @@ async execute<T = string>(
 ### Text Response
 
 ```typescript
-import { ComputerUseAgent } from 'cu-playwright-ts';
+import { ComputerUseAgent } from '@onkernel/cu-playwright-ts';
 
 // Navigate to the target page first
 await page.goto("https://news.ycombinator.com/");
@@ -120,7 +120,7 @@ console.log(result); // "Title of the top story"
 
 ```typescript
 import { z } from 'zod';
-import { ComputerUseAgent } from 'cu-playwright-ts';
+import { ComputerUseAgent } from '@onkernel/cu-playwright-ts';
 
 const agent = new ComputerUseAgent({
   apiKey: process.env.ANTHROPIC_API_KEY!,

--- a/README.md
+++ b/README.md
@@ -1,66 +1,241 @@
 # Computer Use Playwright SDK
 
-A TypeScript SDK that combines Anthropic's Computer Use capabilities with Playwright for browser automation tasks.
+A TypeScript SDK that combines Anthropic's Computer Use capabilities with Playwright for browser automation tasks. This SDK provides a clean, type-safe interface for automating browser interactions using Claude's computer use abilities.
+
+## Features
+
+- 🤖 **Simple API**: Single `ComputerUseAgent` class for all computer use tasks
+- 🔄 **Dual Response Types**: Support for both text and structured (JSON) responses
+- 🛡️ **Type Safety**: Full TypeScript support with Zod schema validation
+- ⚡ **Optimized**: Clean error handling and robust JSON parsing
+- 🎯 **Focused**: Clean API surface with sensible defaults
 
 ## Installation
 
 ```bash
-npm install @onkernel/cu-playwright-ts
+npm install cu-playwright-ts
+# or
+yarn add cu-playwright-ts
+# or
+bun add cu-playwright-ts
 ```
 
-## Usage
+## Quick Start
 
 ```typescript
 import { chromium } from 'playwright';
-import { samplingLoop } from '@onkernel/cu-playwright-ts';
+import { ComputerUseAgent } from 'cu-playwright-ts';
 
-const browser = await chromium.launch();
+const browser = await chromium.launch({ headless: false });
 const page = await browser.newPage();
- await page.goto("https://news.ycombinator.com/newest");
 
-const messages = await samplingLoop({
-  model: 'claude-sonnet-4-20250514',
-  messages: [{
-    role: 'user',
-    content: 'Go to https://example.com and click the search button'
-  }],
+// Navigate to Hacker News manually first
+await page.goto("https://news.ycombinator.com/");
+
+const agent = new ComputerUseAgent({
   apiKey: process.env.ANTHROPIC_API_KEY!,
-  playwrightPage: page,
+  page,
 });
+
+// Simple text response
+const answer = await agent.execute('Tell me the title of the top story');
+console.log(answer);
 
 await browser.close();
 ```
 
-## API
+## API Reference
 
-### `samplingLoop(options)`
+### `ComputerUseAgent`
 
-The main function that executes Computer Use tasks with Playwright.
+The main class for computer use automation.
 
-**Parameters:**
-- `model` (string): Anthropic model to use (e.g., 'claude-3-5-sonnet-20241022')
-- `messages` (BetaMessageParam[]): Array of conversation messages
-- `apiKey` (string): Your Anthropic API key
-- `playwrightPage` (Page): Playwright page instance
-- `systemPromptSuffix?` (string): Optional additional system prompt
-- `maxTokens?` (number): Maximum tokens for response (default: 4096)
-- `toolVersion?` (ToolVersion): Computer Use tool version to use
-- `thinkingBudget?` (number): Token budget for AI thinking
-- `tokenEfficientToolsBeta?` (boolean): Enable token-efficient tools beta
-- `onlyNMostRecentImages?` (number): Limit number of recent images
+#### Constructor
 
-**Returns:** Promise<BetaMessageParam[]> - Array of conversation messages
-
-## Environment Variables
-
-Set your Anthropic API key:
-```bash
-export ANTHROPIC_API_KEY=your_api_key_here
+```typescript
+new ComputerUseAgent(options: {
+  apiKey: string;
+  page: Page;
+  model?: string;
+})
 ```
 
-## Example
+**Parameters:**
+- `apiKey` (string): Your Anthropic API key. Get one from [Anthropic Console](https://console.anthropic.com/)
+- `page` (Page): Playwright page instance to control
+- `model` (string, optional): Anthropic model to use. Defaults to `'claude-3-5-sonnet-20241022'`
 
-See `example.ts` for a complete working example.
+**Supported Models:**
+See [Anthropic's Computer Use documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool#model-compatibility) for the latest model compatibility.
+
+#### `execute()` Method
+
+```typescript
+async execute<T = string>(
+  query: string,
+  schema?: z.ZodSchema<T>,
+  options?: {
+    systemPromptSuffix?: string;
+    thinkingBudget?: number;
+  }
+): Promise<T>
+```
+
+**Parameters:**
+
+- **`query`** (string): The task description for Claude to execute
+  
+- **`schema`** (ZodSchema, optional): Zod schema for structured responses. When provided, the response will be validated against this schema
+  
+- **`options`** (object, optional):
+  - **`systemPromptSuffix`** (string): Additional instructions appended to the system prompt
+  - **`thinkingBudget`** (number): Token budget for Claude's internal reasoning process. Default: `1024`. See [Extended Thinking documentation](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) for details
+
+**Returns:** 
+- `Promise<T>`: When `schema` is provided, returns validated data of type `T`
+- `Promise<string>`: When no `schema` is provided, returns the text response
+
+## Usage Examples
+
+### Text Response
+
+```typescript
+import { ComputerUseAgent } from 'cu-playwright-ts';
+
+// Navigate to the target page first
+await page.goto("https://news.ycombinator.com/");
+
+const agent = new ComputerUseAgent({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  page,
+});
+
+const result = await agent.execute(
+  'Tell me the title of the top story on this page'
+);
+console.log(result); // "Title of the top story"
+```
+
+### Structured Response with Zod
+
+```typescript
+import { z } from 'zod';
+import { ComputerUseAgent } from 'cu-playwright-ts';
+
+const agent = new ComputerUseAgent({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  page,
+});
+
+const HackerNewsStory = z.object({
+  title: z.string(),
+  points: z.number(),
+  author: z.string(),
+  comments: z.number(),
+  url: z.string().optional(),
+});
+
+const stories = await agent.execute(
+  'Get the top 5 Hacker News stories with their details',
+  z.array(HackerNewsStory).max(5)
+);
+
+console.log(stories);
+// [
+//   {
+//     title: "Example Story",
+//     points: 150,
+//     author: "user123",
+//     comments: 42,
+//     url: "https://example.com"
+//   },
+//   ...
+// ]
+```
+
+### Advanced Options
+
+```typescript
+const result = await agent.execute(
+  'Complex task requiring more thinking',
+  undefined, // No schema for text response
+  {
+    systemPromptSuffix: 'Be extra careful with form submissions.',
+    thinkingBudget: 4096, // More thinking tokens for complex tasks
+  }
+);
+```
+
+## Environment Setup
+
+1. **Anthropic API Key**: Set your API key as an environment variable:
+   ```bash
+   export ANTHROPIC_API_KEY=your_api_key_here
+   ```
+
+2. **Playwright**: Install Playwright and browser dependencies:
+   ```bash
+   npx playwright install
+   ```
+
+## Computer Use Parameters
+
+This SDK leverages Anthropic's Computer Use API with the following key parameters:
+
+### Model Selection
+- **Claude 3.5 Sonnet**: Best balance of speed and capability for most tasks
+- **Claude 4 Models**: Enhanced reasoning with extended thinking capabilities
+- **Claude 3.7 Sonnet**: Advanced reasoning with thinking transparency
+
+### Thinking Budget
+The `thinkingBudget` parameter controls Claude's internal reasoning process:
+- **1024 tokens** (default): Suitable for simple tasks
+- **4096+ tokens**: Better for complex reasoning tasks
+- **16k+ tokens**: Recommended for highly complex multi-step operations
+
+See [Anthropic's Extended Thinking guide](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#working-with-thinking-budgets) for optimization tips.
+
+## Error Handling
+
+The SDK includes built-in error handling:
+
+```typescript
+try {
+  const result = await agent.execute('Your task here');
+  console.log(result);
+} catch (error) {
+  if (error.message.includes('No response received')) {
+    console.log('Agent did not receive a response from Claude');
+  } else {
+    console.log('Other error:', error.message);
+  }
+}
+```
+
+## Best Practices
+
+1. **Use specific, clear instructions**: "Click the red 'Submit' button" vs "click submit"
+
+2. **For complex tasks, break them down**: Use step-by-step instructions in your query
+
+3. **Optimize thinking budget**: Start with default (1024) and increase for complex tasks
+
+4. **Handle errors gracefully**: Implement proper error handling for production use
+
+5. **Use structured responses**: When you need specific data format, use Zod schemas
+
+6. **Test in headless: false**: During development, run with visible browser to debug
+
+## Security Considerations
+
+⚠️ **Important**: Computer use can interact with any visible application. Always:
+
+- Run in isolated environments (containers/VMs) for production
+- Avoid providing access to sensitive accounts or data
+- Review Claude's actions in logs before production deployment
+- Use allowlisted domains when possible
+
+See [Anthropic's Computer Use Security Guide](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool#security-considerations) for detailed security recommendations.
 
 ## Requirements
 
@@ -69,11 +244,18 @@ See `example.ts` for a complete working example.
 - Playwright 1.52+
 - Anthropic API key
 
+## Related Resources
+
+- [Anthropic Computer Use Documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool)
+- [Extended Thinking Guide](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
+- [Playwright Documentation](https://playwright.dev/)
+- [Zod Documentation](https://zod.dev/)
+
 ## License
 
 MIT
 
-Copyright (c) 2025 Kernel
+Copyright (c) 2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
-# cu-playwright-ts
-Computer Use x Playwright SDK
+# Computer Use Playwright SDK
+
+A TypeScript SDK that combines Anthropic's Computer Use capabilities with Playwright for browser automation tasks.
+
+## Installation
+
+```bash
+npm install @onkernel/cu-playwright-ts
+```
+
+## Usage
+
+```typescript
+import { chromium } from 'playwright';
+import { samplingLoop } from '@onkernel/cu-playwright-ts';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+ await page.goto("https://news.ycombinator.com/newest");
+
+const messages = await samplingLoop({
+  model: 'claude-sonnet-4-20250514',
+  messages: [{
+    role: 'user',
+    content: 'Go to https://example.com and click the search button'
+  }],
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  playwrightPage: page,
+});
+
+await browser.close();
+```
+
+## API
+
+### `samplingLoop(options)`
+
+The main function that executes Computer Use tasks with Playwright.
+
+**Parameters:**
+- `model` (string): Anthropic model to use (e.g., 'claude-3-5-sonnet-20241022')
+- `messages` (BetaMessageParam[]): Array of conversation messages
+- `apiKey` (string): Your Anthropic API key
+- `playwrightPage` (Page): Playwright page instance
+- `systemPromptSuffix?` (string): Optional additional system prompt
+- `maxTokens?` (number): Maximum tokens for response (default: 4096)
+- `toolVersion?` (ToolVersion): Computer Use tool version to use
+- `thinkingBudget?` (number): Token budget for AI thinking
+- `tokenEfficientToolsBeta?` (boolean): Enable token-efficient tools beta
+- `onlyNMostRecentImages?` (number): Limit number of recent images
+
+**Returns:** Promise<BetaMessageParam[]> - Array of conversation messages
+
+## Environment Variables
+
+Set your Anthropic API key:
+```bash
+export ANTHROPIC_API_KEY=your_api_key_here
+```
+
+## Example
+
+See `example.ts` for a complete working example.
+
+## Requirements
+
+- Node.js 18+
+- TypeScript 5+
+- Playwright 1.52+
+- Anthropic API key
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ new ComputerUseAgent(options: {
 **Parameters:**
 - `apiKey` (string): Your Anthropic API key. Get one from [Anthropic Console](https://console.anthropic.com/)
 - `page` (Page): Playwright page instance to control
-- `model` (string, optional): Anthropic model to use. Defaults to `'claude-3-5-sonnet-20241022'`
+- `model` (string, optional): Anthropic model to use. Defaults to `'claude-sonnet-4-20250514'`
 
 **Supported Models:**
 See [Anthropic's Computer Use documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool#model-compatibility) for the latest model compatibility.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,23 @@ See `example.ts` for a complete working example.
 ## License
 
 MIT
+
+Copyright (c) 2025 Kernel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agent.ts
+++ b/agent.ts
@@ -1,0 +1,170 @@
+import { z } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
+import type { Page } from 'playwright';
+import { computerUseLoop } from './loop';
+
+/**
+ * Computer Use Agent for automating browser interactions with Claude
+ * 
+ * This agent provides a clean interface to Anthropic's Computer Use capabilities,
+ * allowing Claude to interact with web pages through Playwright.
+ * 
+ * @see https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool
+ */
+export class ComputerUseAgent {
+  private apiKey: string;
+  private model: string;
+  private page: Page;
+
+  /**
+   * Create a new ComputerUseAgent instance
+   * 
+   * @param options - Configuration options
+   * @param options.apiKey - Anthropic API key (get one from https://console.anthropic.com/)
+   * @param options.page - Playwright page instance to control
+   * @param options.model - Anthropic model to use (defaults to claude-sonnet-4-20250514)
+   * 
+   * @see https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool#model-compatibility
+   */
+  constructor({
+    apiKey,
+    page,
+    model = 'claude-sonnet-4-20250514',
+  }: {
+    /** Anthropic API key for authentication */
+    apiKey: string;
+    /** Playwright page instance to control */
+    page: Page;
+    /** 
+     * Anthropic model to use for computer use tasks
+     * @default 'claude-sonnet-4-20250514'
+     */
+    model?: string;
+  }) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.page = page;
+  }
+
+  /**
+   * Execute a computer use task with Claude
+   * 
+   * This method can return either text responses or structured data validated against a Zod schema.
+   * 
+   * @template T - The expected return type (string by default, or inferred from schema)
+   * @param query - The task description for Claude to execute
+   * @param schema - Optional Zod schema for structured responses
+   * @param options - Additional execution options
+   * @param options.systemPromptSuffix - Additional instructions appended to the system prompt
+   * @param options.thinkingBudget - Token budget for Claude's internal reasoning (default: 1024)
+   * 
+   * @returns Promise that resolves to either a string (when no schema) or validated data of type T
+   * 
+   * @example
+   * ```typescript
+   * // Text response
+   * const result = await agent.execute('Tell me the page title');
+   * 
+   * // Structured response
+   * const data = await agent.execute(
+   *   'Get user info',
+   *   z.object({ name: z.string(), age: z.number() })
+   * );
+   * ```
+   * 
+   * @see https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+   */
+  async execute<T = string>(
+    query: string,
+    schema?: z.ZodSchema<T>,
+    options?: {
+      /** Additional instructions appended to the system prompt */
+      systemPromptSuffix?: string;
+      /** 
+       * Token budget for Claude's internal reasoning process
+       * @default 1024
+       * @see https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#working-with-thinking-budgets
+       */
+      thinkingBudget?: number;
+    }
+  ): Promise<T> {
+    const { systemPromptSuffix, thinkingBudget } = options ?? {};
+
+    // Prepare query with schema instructions if schema is provided
+    let finalQuery = query;
+    if (schema) {
+      const jsonSchema = zodToJsonSchema(schema);
+      finalQuery = `${query}
+
+Please respond with a valid JSON object that matches this JSON Schema:
+\`\`\`json
+${JSON.stringify(jsonSchema, null, 2)}
+\`\`\`
+
+Respond ONLY with the JSON object, no additional text.`;
+    }
+
+    // Execute the computer use loop
+    const messages = await computerUseLoop({
+      query: finalQuery,
+      apiKey: this.apiKey,
+      playwrightPage: this.page,
+      model: this.model,
+      systemPromptSuffix,
+      thinkingBudget,
+    });
+
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) {
+      throw new Error('No response received');
+    }
+
+    const response = this.extractTextFromMessage(lastMessage);
+
+    // If no schema provided, return string response
+    if (!schema) {
+      return response as T;
+    }
+
+    // Parse and validate structured response
+    const parsed = this.parseJsonResponse(response);
+    return schema.parse(parsed);
+  }
+
+  private extractTextFromMessage(message: { content: string | Array<{ type: string; text?: string }> }): string {
+    if (typeof message.content === 'string') {
+      return message.content;
+    }
+    
+    if (Array.isArray(message.content)) {
+      return message.content
+        .filter((block) => block.type === 'text')
+        .map((block) => block.text || '')
+        .join('');
+    }
+    
+    return '';
+  }
+
+  private parseJsonResponse(response: string): unknown {
+    // Example: "Here's the data:\n```json\n{\"name\": \"John\", \"age\": 30}\n```\nHope this helps!"
+    // Example: "```\n{\"status\": \"success\"}\n```"
+    const jsonMatch = response.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+    if (jsonMatch && jsonMatch[1]) {
+      return JSON.parse(jsonMatch[1].trim());
+    }
+
+    // Example: "The user data is {\"name\": \"John\", \"age\": 30} as requested."
+    // Example: "Result: {\"items\": [1, 2, 3], \"total\": 3}"
+    const objectMatch = response.match(/\{[\s\S]*\}/);
+    if (objectMatch && objectMatch[0]) {
+      return JSON.parse(objectMatch[0]);
+    }
+
+    // Example: "{\"name\": \"John\", \"age\": 30}" (clean JSON response)
+    // Example: "  {\"status\": \"ok\"}  " (JSON with whitespace)
+    return JSON.parse(response.trim());
+  }
+
+
+} 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "0.52.0",
         "luxon": "3.6.0",
+        "zod": "^3.25.0",
+        "zod-to-json-schema": "^3.23.1",
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
@@ -258,6 +260,10 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.25.67", "", {}, "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,278 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@onkernel/cu-playwright-ts",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.52.0",
+        "luxon": "3.6.0",
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^9.0.0",
+      },
+      "peerDependencies": {
+        "playwright": "^1.52.0",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.20.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.6", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.2.3", "", {}, "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg=="],
+
+    "@eslint/core": ["@eslint/core@0.14.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
+
+    "@eslint/js": ["@eslint/js@9.29.0", "", {}, "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.2", "", { "dependencies": { "@eslint/core": "^0.15.0", "levn": "^0.4.1" } }, "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.34.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.34.1", "@typescript-eslint/type-utils": "8.34.1", "@typescript-eslint/utils": "8.34.1", "@typescript-eslint/visitor-keys": "8.34.1", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.34.1", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.34.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.34.1", "@typescript-eslint/types": "8.34.1", "@typescript-eslint/typescript-estree": "8.34.1", "@typescript-eslint/visitor-keys": "8.34.1", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.34.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.34.1", "@typescript-eslint/types": "^8.34.1", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.34.1", "", { "dependencies": { "@typescript-eslint/types": "8.34.1", "@typescript-eslint/visitor-keys": "8.34.1" } }, "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.34.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.34.1", "", { "dependencies": { "@typescript-eslint/typescript-estree": "8.34.1", "@typescript-eslint/utils": "8.34.1", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.34.1", "", {}, "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.34.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.34.1", "@typescript-eslint/tsconfig-utils": "8.34.1", "@typescript-eslint/types": "8.34.1", "@typescript-eslint/visitor-keys": "8.34.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.34.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.34.1", "@typescript-eslint/types": "8.34.1", "@typescript-eslint/typescript-estree": "8.34.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.34.1", "", { "dependencies": { "@typescript-eslint/types": "8.34.1", "eslint-visitor-keys": "^4.2.1" } }, "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.29.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.20.1", "@eslint/config-helpers": "^0.2.1", "@eslint/core": "^0.14.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.29.0", "@eslint/plugin-kit": "^0.3.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@9.1.0", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "luxon": ["luxon@3.6.0", "", {}, "sha512-WE7p0p7W1xji9qxkLYsvcIxZyfP48GuFrWIBQZIsbjCyf65dG1rv4n83HcOyEyhvzxJCrUoObCRNFgRNIQ5KNA=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "playwright": ["playwright@1.53.0", "", { "dependencies": { "playwright-core": "1.53.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q=="],
+
+    "playwright-core": ["playwright-core@1.53.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.15.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw=="],
+
+    "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+import eslint from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+import prettierConfig from 'eslint-config-prettier';
+
+export default [
+  {
+    ignores: ['**/dist/']
+  },
+  eslint.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx,mts,cts}'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        project: './tsconfig.json',
+        ecmaVersion: 2025,
+        sourceType: 'module',
+        jsx: true,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', ignoreRestSiblings: true },
+      ],
+      'no-unused-vars': 'off', // Turn off the base rule since we have the TS-specific one
+      'no-undef': 'off', // TypeScript will catch these errors instead
+    },
+  },
+  prettierConfig,
+]; 

--- a/example.ts
+++ b/example.ts
@@ -1,0 +1,49 @@
+import { chromium } from 'playwright';
+import { samplingLoop } from './index';
+
+// Example usage of the Computer Use Playwright SDK
+async function example(): Promise<void> {
+  // Your Anthropic API key
+  const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+  
+  if (!ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required');
+  }
+  
+  // Launch a browser
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  
+  await page.goto("https://news.ycombinator.com/newest");
+
+  try {
+    // Use the samplingLoop to have the AI perform a task
+    const messages = await samplingLoop({
+      model: 'claude-sonnet-4-20250514',
+      messages: [{
+        role: 'user',
+        content: 'Get the top 5 posts on hackernews homepage'
+      }],
+      apiKey: ANTHROPIC_API_KEY,
+      thinkingBudget: 1024,
+      playwrightPage: page,
+    });
+    
+    console.log('Task completed!');
+    console.log('Final messages:', messages.length);
+    
+    // Extract the final assistant response
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage && lastMessage.role === 'assistant') {
+      console.log('Final response:', lastMessage.content);
+    }
+    
+  } catch (error) {
+    console.error('Error during task execution:', error);
+  } finally {
+    await browser.close();
+  }
+}
+
+example().catch(console.error); 

--- a/example.ts
+++ b/example.ts
@@ -1,49 +1,101 @@
 import { chromium } from 'playwright';
-import { samplingLoop } from './index';
+import { z } from 'zod';
+import { ComputerUseAgent } from './index';
 
-// Example usage of the Computer Use Playwright SDK
-async function example(): Promise<void> {
-  // Your Anthropic API key
+async function textResponseExample(): Promise<void> {
   const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-  
   if (!ANTHROPIC_API_KEY) {
     throw new Error('ANTHROPIC_API_KEY environment variable is required');
   }
   
-  // Launch a browser
   const browser = await chromium.launch({ headless: false });
-  const context = await browser.newContext();
-  const page = await context.newPage();
+  const page = await browser.newPage();
+  await page.goto("https://news.ycombinator.com/");
   
-  await page.goto("https://news.ycombinator.com/newest");
-
   try {
-    // Use the samplingLoop to have the AI perform a task
-    const messages = await samplingLoop({
-      model: 'claude-sonnet-4-20250514',
-      messages: [{
-        role: 'user',
-        content: 'Get the top 5 posts on hackernews homepage'
-      }],
+    console.log('\n=== Text Response Examples ===');
+    const agent = new ComputerUseAgent({
       apiKey: ANTHROPIC_API_KEY,
-      thinkingBudget: 1024,
-      playwrightPage: page,
+      page,
     });
     
-    console.log('Task completed!');
-    console.log('Final messages:', messages.length);
-    
-    // Extract the final assistant response
-    const lastMessage = messages[messages.length - 1];
-    if (lastMessage && lastMessage.role === 'assistant') {
-      console.log('Final response:', lastMessage.content);
-    }
+    // Text response with action
+    const topStory = await agent.execute('Tell me the title of the top story on this page');
+    console.log('Top story:', topStory);
+
+    // Text response with multiple pieces of information
+    const summary = await agent.execute('Give me a brief summary of the top 3 stories');
+    console.log('Summary:', summary);
     
   } catch (error) {
-    console.error('Error during task execution:', error);
+    console.error('Error in text response example:', error);
   } finally {
     await browser.close();
   }
 }
 
-example().catch(console.error); 
+async function structuredResponseExample(): Promise<void> {
+  const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+  if (!ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required');
+  }
+  
+  const browser = await chromium.launch({ headless: false });
+  const page = await browser.newPage();
+  await page.goto("https://news.ycombinator.com/");
+  
+  try {
+    console.log('\n=== Structured Response Examples ===');
+    const agent = new ComputerUseAgent({
+      apiKey: ANTHROPIC_API_KEY,
+      page,
+    });
+    
+    // Define schema for a single story
+    const HackerNewsStory = z.object({
+      title: z.string(),
+      points: z.number(),
+      author: z.string(),
+      comments: z.number(),
+      url: z.string().optional(),
+    });
+    
+    // Get multiple stories with structured data
+    const stories = await agent.execute(
+      'Get the top 5 stories with their titles, points, authors, and comment counts',
+      z.array(HackerNewsStory).max(5)
+    );
+    console.log('Structured stories:', JSON.stringify(stories, null, 2));
+
+    // Define schema for page metadata
+    const PageInfo = z.object({
+      title: z.string(),
+      totalStories: z.number(),
+      currentPage: z.number(),
+    });
+
+    // Get page information with structured data
+    const pageInfo = await agent.execute(
+      'Get information about this page including its title, total number of stories visible, and current page number',
+      PageInfo
+    );
+    console.log('Page info:', JSON.stringify(pageInfo, null, 2));
+    
+  } catch (error) {
+    console.error('Error in structured response example:', error);
+  } finally {
+    await browser.close();
+  }
+}
+
+// Run examples
+async function runExamples(): Promise<void> {
+  console.log('Running Computer Use Agent Examples...');
+  
+  await textResponseExample();
+  await structuredResponseExample();
+  
+  console.log('\nAll examples completed!');
+}
+
+runExamples().catch(console.error); 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-export { samplingLoop } from './loop';
+export { ComputerUseAgent } from './agent';
 export type { BetaMessageParam, BetaTextBlock } from './types/beta';
 export type { ToolVersion } from './tools/collection';
 export { Action } from './tools/types/computer';

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+export { samplingLoop } from './loop';
+export type { BetaMessageParam, BetaTextBlock } from './types/beta';
+export type { ToolVersion } from './tools/collection';
+export { Action } from './tools/types/computer';

--- a/loop.ts
+++ b/loop.ts
@@ -191,3 +191,66 @@ export async function samplingLoop({
     }
   }
 }
+
+/**
+ * Simplified computer use loop for executing tasks with Claude
+ * 
+ * This function provides a higher-level interface to the sampling loop,
+ * accepting a simple query string instead of message arrays.
+ * 
+ * @param options - Configuration options
+ * @param options.query - The task description for Claude to execute
+ * @param options.apiKey - Anthropic API key for authentication
+ * @param options.playwrightPage - Playwright page instance to control
+ * @param options.model - Anthropic model to use (default: claude-sonnet-4-20250514)
+ * @param options.systemPromptSuffix - Additional instructions appended to system prompt
+ * @param options.maxTokens - Maximum tokens for response (default: 4096)
+ * @param options.toolVersion - Computer use tool version (auto-selected based on model)
+ * @param options.thinkingBudget - Token budget for Claude's reasoning (default: 1024)
+ * @param options.tokenEfficientToolsBeta - Enable token-efficient tools beta
+ * @param options.onlyNMostRecentImages - Limit number of recent images to include
+ * 
+ * @returns Promise resolving to array of conversation messages
+ * 
+ * @see https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+ */
+export async function computerUseLoop({
+  query,
+  apiKey,
+  playwrightPage,
+  model = 'claude-sonnet-4-20250514',
+  systemPromptSuffix,
+  maxTokens = 4096,
+  toolVersion,
+  thinkingBudget = 1024,
+  tokenEfficientToolsBeta = false,
+  onlyNMostRecentImages,
+}: {
+  query: string;
+  apiKey: string;
+  playwrightPage: Page;
+  model?: string;
+  systemPromptSuffix?: string;
+  maxTokens?: number;
+  toolVersion?: ToolVersion;
+  thinkingBudget?: number;
+  tokenEfficientToolsBeta?: boolean;
+  onlyNMostRecentImages?: number;
+}): Promise<BetaMessageParam[]> {
+  return samplingLoop({
+    model,
+    systemPromptSuffix,
+    messages: [{
+      role: 'user',
+      content: query,
+    }],
+    apiKey,
+    maxTokens,
+    toolVersion,
+    thinkingBudget,
+    tokenEfficientToolsBeta,
+    onlyNMostRecentImages,
+    playwrightPage,
+  });
+}

--- a/loop.ts
+++ b/loop.ts
@@ -1,0 +1,193 @@
+import { Anthropic } from '@anthropic-ai/sdk';
+import { DateTime } from 'luxon';
+import type { Page } from 'playwright';
+import type { BetaMessageParam, BetaTextBlock } from './types/beta';
+import { ToolCollection, DEFAULT_TOOL_VERSION, TOOL_GROUPS_BY_VERSION, type ToolVersion } from './tools/collection';
+import { responseToParams, maybeFilterToNMostRecentImages, injectPromptCaching, PROMPT_CACHING_BETA_FLAG } from './utils/message-processing';
+import { makeApiToolResult } from './utils/tool-results';
+import { ComputerTool20241022, ComputerTool20250124 } from './tools/computer';
+import type { ActionParams } from './tools/types/computer';
+import { Action } from './tools/types/computer';
+
+// System prompt optimized for the environment
+const SYSTEM_PROMPT = `<SYSTEM_CAPABILITY>
+* You are utilising an Ubuntu virtual machine using ${process.arch} architecture with internet access.
+* When you connect to the display, CHROMIUM IS ALREADY OPEN. The url bar is not visible but it is there.
+* If you need to navigate to a new page, use ctrl+l to focus the url bar and then enter the url.
+* You won't be able  to see the url bar from the screenshot but ctrl-l still works.
+* When viewing a page it can be helpful to zoom out so that you can see everything on the page.
+* Either that, or make sure you scroll down to see everything before deciding something isn't available.
+* When using your computer function calls, they take a while to run and send back to you.
+* Where possible/feasible, try to chain multiple of these calls all into one function calls request.
+* The current date is ${DateTime.now().toFormat('EEEE, MMMM d, yyyy')}.
+* After each step, take a screenshot and carefully evaluate if you have achieved the right outcome.
+* Explicitly show your thinking: "I have evaluated step X..." If not correct, try again.
+* Only when you confirm a step was executed correctly should you move on to the next one.
+</SYSTEM_CAPABILITY>
+
+<IMPORTANT>
+* When using Chromium, if a startup wizard appears, IGNORE IT. Do not even click "skip this step".
+* Instead, click on the search bar on the center of the screen where it says "Search or enter address", and enter the appropriate search term or URL there.
+</IMPORTANT>`;
+
+// Add new type definitions
+interface ThinkingConfig {
+  type: 'enabled';
+  budget_tokens: number;
+}
+
+interface ExtraBodyConfig {
+  thinking?: ThinkingConfig;
+}
+
+interface ToolUseInput extends Record<string, unknown> {
+  action: Action;
+}
+
+export async function samplingLoop({
+  model,
+  systemPromptSuffix,
+  messages,
+  apiKey,
+  onlyNMostRecentImages,
+  maxTokens = 4096,
+  toolVersion,
+  thinkingBudget,
+  tokenEfficientToolsBeta = false,
+  playwrightPage,
+}: {
+  model: string;
+  systemPromptSuffix?: string;
+  messages: BetaMessageParam[];
+  apiKey: string;
+  onlyNMostRecentImages?: number;
+  maxTokens?: number;
+  toolVersion?: ToolVersion;
+  thinkingBudget?: number;
+  tokenEfficientToolsBeta?: boolean;
+  playwrightPage: Page;
+}): Promise<BetaMessageParam[]> {
+  const selectedVersion = toolVersion || DEFAULT_TOOL_VERSION;
+  const toolGroup = TOOL_GROUPS_BY_VERSION[selectedVersion];
+  const toolCollection = new ToolCollection(...toolGroup.tools.map((Tool: typeof ComputerTool20241022 | typeof ComputerTool20250124) => new Tool(playwrightPage)));
+  
+  const system: BetaTextBlock = {
+    type: 'text',
+    text: `${SYSTEM_PROMPT}${systemPromptSuffix ? ' ' + systemPromptSuffix : ''}`,
+  };
+
+  while (true) {
+    const betas: string[] = toolGroup.beta_flag ? [toolGroup.beta_flag] : [];
+    
+    if (tokenEfficientToolsBeta) {
+      betas.push('token-efficient-tools-2025-02-19');
+    }
+
+    let imageTruncationThreshold = onlyNMostRecentImages || 0;
+
+    const client = new Anthropic({ apiKey, maxRetries: 4 });
+    const enablePromptCaching = true;
+    
+    if (enablePromptCaching) {
+      betas.push(PROMPT_CACHING_BETA_FLAG);
+      injectPromptCaching(messages);
+      onlyNMostRecentImages = 0;
+      (system as BetaTextBlock).cache_control = { type: 'ephemeral' };
+    }
+
+    if (onlyNMostRecentImages) {
+      maybeFilterToNMostRecentImages(
+        messages,
+        onlyNMostRecentImages,
+        imageTruncationThreshold
+      );
+    }
+
+    const extraBody: ExtraBodyConfig = {};
+    if (thinkingBudget) {
+      extraBody.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
+    }
+
+    const toolParams = toolCollection.toParams();
+
+    const response = await client.beta.messages.create({
+      max_tokens: maxTokens,
+      messages,
+      model,
+      system: [system],
+      tools: toolParams,
+      betas,
+      ...extraBody,
+    });
+
+    const responseParams = responseToParams(response);
+    
+    const loggableContent = responseParams.map(block => {
+      if (block.type === 'tool_use') {
+        return {
+          type: 'tool_use',
+          name: block.name,
+          input: block.input
+        };
+      }
+      return block;
+    });
+    console.log('=== LLM RESPONSE ===');
+    console.log('Stop reason:', response.stop_reason);
+    console.log(loggableContent);
+    console.log("===")
+    
+    messages.push({
+      role: 'assistant',
+      content: responseParams,
+    });
+
+    if (response.stop_reason === 'end_turn') {
+      console.log('LLM has completed its task, ending loop');
+      return messages;
+    }
+
+    const toolResultContent = [];
+    let hasToolUse = false;
+    
+    for (const contentBlock of responseParams) {
+      if (contentBlock.type === 'tool_use' && contentBlock.name && contentBlock.input && typeof contentBlock.input === 'object') {
+        const input = contentBlock.input as ToolUseInput;
+        if ('action' in input && typeof input.action === 'string') {
+          hasToolUse = true;
+          const toolInput: ActionParams = {
+            action: input.action as Action,
+            ...Object.fromEntries(
+              Object.entries(input).filter(([key]) => key !== 'action')
+            )
+          };
+          
+          try {
+            const result = await toolCollection.run(
+              contentBlock.name,
+              toolInput
+            );
+
+            const toolResult = makeApiToolResult(result, contentBlock.id!);
+            toolResultContent.push(toolResult);
+          } catch (error) {
+            console.error(error);
+            throw error;
+          }
+        }
+      }
+    }
+
+    if (toolResultContent.length === 0 && !hasToolUse && response.stop_reason !== 'tool_use') {
+      console.log('No tool use or results, and not waiting for tool use, ending loop');
+      return messages;
+    }
+
+    if (toolResultContent.length > 0) {
+      messages.push({
+        role: 'user',
+        content: toolResultContent,
+      });
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.52.0",
-    "luxon": "3.6.0"
+    "luxon": "3.6.0",
+    "zod": "^3.25.0",
+    "zod-to-json-schema": "^3.23.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@onkernel/cu-playwright-ts",
+  "version": "0.1.0",
+  "description": "Computer Use x Playwright SDK - Use Anthropic's Computer Use capabilities with Playwright",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "bun build ./index.ts --outdir ./dist --target node",
+    "format": "bun run eslint . --fix",
+    "lint": "bun run eslint .",
+    "lint:fix": "bun run eslint . --fix",
+    "prepublishOnly": "bun run lint && bun run build"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./index.ts"
+    }
+  },
+  "files": [
+    "dist/",
+    "index.ts",
+    "loop.ts",
+    "tools/",
+    "types/",
+    "utils/"
+  ],
+  "keywords": [
+    "computer-use",
+    "playwright",
+    "anthropic",
+    "automation",
+    "ai",
+    "typescript"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "peerDependencies": {
+    "typescript": "^5",
+    "playwright": "^1.52.0"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "0.52.0",
+    "luxon": "3.6.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^9.0.0"
+  }
+}

--- a/tools/collection.ts
+++ b/tools/collection.ts
@@ -1,0 +1,61 @@
+import { ComputerTool20241022, ComputerTool20250124 } from './computer';
+import { Action } from './types/computer';
+import type { ActionParams, ToolResult } from './types/computer';
+
+export type ToolVersion = 'computer_use_20250124' | 'computer_use_20241022' | 'computer_use_20250429';
+
+export const DEFAULT_TOOL_VERSION: ToolVersion = 'computer_use_20250429';
+
+interface ToolGroup {
+  readonly version: ToolVersion;
+  readonly tools: (typeof ComputerTool20241022 | typeof ComputerTool20250124)[];
+  readonly beta_flag: string;
+}
+
+export const TOOL_GROUPS: ToolGroup[] = [
+  {
+    version: 'computer_use_20241022',
+    tools: [ComputerTool20241022],
+    beta_flag: 'computer-use-2024-10-22',
+  },
+  {
+    version: 'computer_use_20250124',
+    tools: [ComputerTool20250124],
+    beta_flag: 'computer-use-2025-01-24',
+  },
+  // 20250429 version inherits from 20250124
+  {
+    version: 'computer_use_20250429',
+    tools: [ComputerTool20250124],
+    beta_flag: 'computer-use-2025-01-24',
+  },
+];
+
+export const TOOL_GROUPS_BY_VERSION: Record<ToolVersion, ToolGroup> = Object.fromEntries(
+  TOOL_GROUPS.map(group => [group.version, group])
+) as Record<ToolVersion, ToolGroup>;
+
+export class ToolCollection {
+  private tools: Map<string, ComputerTool20241022 | ComputerTool20250124>;
+
+  constructor(...tools: (ComputerTool20241022 | ComputerTool20250124)[]) {
+    this.tools = new Map(tools.map(tool => [tool.name, tool]));
+  }
+
+  toParams(): ActionParams[] {
+    return Array.from(this.tools.values()).map(tool => tool.toParams());
+  }
+
+  async run(name: string, toolInput: { action: Action } & Record<string, ActionParams>): Promise<ToolResult> {
+    const tool = this.tools.get(name);
+    if (!tool) {
+      throw new Error(`Tool ${name} not found`);
+    }
+
+    if (!Object.values(Action).includes(toolInput.action)) {
+      throw new Error(`Invalid action ${toolInput.action} for tool ${name}`);
+    }
+
+    return await tool.call(toolInput);
+  }
+} 

--- a/tools/computer.ts
+++ b/tools/computer.ts
@@ -1,0 +1,242 @@
+import type { Page } from 'playwright';
+import { Action, ToolError } from './types/computer';
+import type { ActionParams, BaseAnthropicTool, ToolResult } from './types/computer';
+import { KeyboardUtils } from './utils/keyboard';
+import { ActionValidator } from './utils/validator';
+
+const TYPING_DELAY_MS = 12;
+
+export class ComputerTool implements BaseAnthropicTool {
+  name: 'computer' = 'computer';
+  protected page: Page;
+  protected _screenshotDelay = 2.0;
+  protected version: '20241022' | '20250124';
+
+  private readonly mouseActions = new Set([
+    Action.LEFT_CLICK,
+    Action.RIGHT_CLICK,
+    Action.MIDDLE_CLICK,
+    Action.DOUBLE_CLICK,
+    Action.TRIPLE_CLICK,
+    Action.MOUSE_MOVE,
+    Action.LEFT_CLICK_DRAG,
+    Action.LEFT_MOUSE_DOWN,
+    Action.LEFT_MOUSE_UP,
+  ]);
+
+  private readonly keyboardActions = new Set([
+    Action.KEY,
+    Action.TYPE,
+    Action.HOLD_KEY,
+  ]);
+
+  private readonly systemActions = new Set([
+    Action.SCREENSHOT,
+    Action.CURSOR_POSITION,
+    Action.SCROLL,
+    Action.WAIT,
+  ]);
+
+  constructor(page: Page, version: '20241022' | '20250124' = '20250124') {
+    this.page = page;
+    this.version = version;
+  }
+
+  get apiType(): 'computer_20241022' | 'computer_20250124' {
+    return this.version === '20241022' ? 'computer_20241022' : 'computer_20250124';
+  }
+
+  toParams(): ActionParams {
+    const params = {
+      name: this.name,
+      type: this.apiType,
+      display_width_px: 1280,
+      display_height_px: 720,
+      display_number: null,
+    };
+    return params;
+  }
+
+  private getMouseButton(action: Action): 'left' | 'right' | 'middle' {
+    switch (action) {
+      case Action.LEFT_CLICK:
+      case Action.DOUBLE_CLICK:
+      case Action.TRIPLE_CLICK:
+      case Action.LEFT_CLICK_DRAG:
+      case Action.LEFT_MOUSE_DOWN:
+      case Action.LEFT_MOUSE_UP:
+        return 'left';
+      case Action.RIGHT_CLICK:
+        return 'right';
+      case Action.MIDDLE_CLICK:
+        return 'middle';
+      default:
+        throw new ToolError(`Invalid mouse action: ${action}`);
+    }
+  }
+
+  private async handleMouseAction(action: Action, coordinate: [number, number]): Promise<ToolResult> {
+    const [x, y] = ActionValidator.validateAndGetCoordinates(coordinate);
+    await this.page.mouse.move(x, y);
+    await this.page.waitForTimeout(100);
+
+    if (action === Action.LEFT_MOUSE_DOWN) {
+      await this.page.mouse.down();
+    } else if (action === Action.LEFT_MOUSE_UP) {
+      await this.page.mouse.up();
+    } else {
+      const button = this.getMouseButton(action);
+      if (action === Action.DOUBLE_CLICK) {
+        await this.page.mouse.dblclick(x, y, { button });
+      } else if (action === Action.TRIPLE_CLICK) {
+        await this.page.mouse.click(x, y, { button, clickCount: 3 });
+      } else {
+        await this.page.mouse.click(x, y, { button });
+      }
+    }
+
+    await this.page.waitForTimeout(500);
+    return await this.screenshot();
+  }
+
+  private async handleKeyboardAction(action: Action, text: string, duration?: number): Promise<ToolResult> {
+    if (action === Action.HOLD_KEY) {
+      const key = KeyboardUtils.getPlaywrightKey(text);
+      await this.page.keyboard.down(key);
+      await new Promise(resolve => setTimeout(resolve, duration! * 1000));
+      await this.page.keyboard.up(key);
+    } else if (action === Action.KEY) {
+      const keys = KeyboardUtils.parseKeyCombination(text);
+      for (const key of keys) {
+        await this.page.keyboard.down(key);
+      }
+      for (const key of keys.reverse()) {
+        await this.page.keyboard.up(key);
+      }
+    } else {
+      await this.page.keyboard.type(text, { delay: TYPING_DELAY_MS });
+    }
+
+    await this.page.waitForTimeout(500);
+    return await this.screenshot();
+  }
+
+  async screenshot(): Promise<ToolResult> {
+    try {
+      console.log('Starting screenshot...');
+      await new Promise(resolve => setTimeout(resolve, this._screenshotDelay * 1000));
+      const screenshot = await this.page.screenshot({ type: 'png' });
+      console.log('Screenshot taken, size:', screenshot.length, 'bytes');
+
+      return {
+        base64Image: screenshot.toString('base64'),
+      };
+    } catch (error) {
+      throw new ToolError(`Failed to take screenshot: ${error}`);
+    }
+  }
+
+  async call(params: ActionParams): Promise<ToolResult> {
+    const { 
+      action, 
+      text, 
+      coordinate, 
+      scrollDirection: scrollDirectionParam,
+      scroll_amount,
+      scrollAmount,
+      duration, 
+      ...kwargs 
+    } = params;
+
+    ActionValidator.validateActionParams(params, this.mouseActions, this.keyboardActions);
+
+    if (action === Action.SCREENSHOT) {
+      return await this.screenshot();
+    }
+
+    if (action === Action.CURSOR_POSITION) {
+      const position = await this.page.evaluate(() => {
+        const selection = window.getSelection();
+        const range = selection?.getRangeAt(0);
+        const rect = range?.getBoundingClientRect();
+        return rect ? { x: rect.x, y: rect.y } : null;
+      });
+      
+      if (!position) {
+        throw new ToolError('Failed to get cursor position');
+      }
+      
+      return { output: `X=${position.x},Y=${position.y}` };
+    }
+
+    if (action === Action.SCROLL) {
+      if (this.version !== '20250124') {
+        throw new ToolError(`${action} is only available in version 20250124`);
+      }
+
+      const scrollDirection = scrollDirectionParam || kwargs.scroll_direction;
+      const scrollAmountValue = scrollAmount || scroll_amount;
+
+      if (!scrollDirection || !['up', 'down', 'left', 'right'].includes(scrollDirection)) {
+        throw new ToolError(`Scroll direction "${scrollDirection}" must be 'up', 'down', 'left', or 'right'`);
+      }
+      if (typeof scrollAmountValue !== 'number' || scrollAmountValue < 0) {
+        throw new ToolError(`Scroll amount "${scrollAmountValue}" must be a non-negative number`);
+      }
+
+      if (coordinate) {
+        const [x, y] = ActionValidator.validateAndGetCoordinates(coordinate);
+        await this.page.mouse.move(x, y);
+        await this.page.waitForTimeout(100);
+      }
+
+      const amount = scrollAmountValue || 100;
+      
+      if (scrollDirection === 'down' || scrollDirection === 'up') {
+        await this.page.mouse.wheel(0, scrollDirection === 'down' ? amount : -amount);
+      } else {
+        await this.page.mouse.wheel(scrollDirection === 'right' ? amount : -amount, 0);
+      }
+      
+      await this.page.waitForTimeout(500);
+      return await this.screenshot();
+    }
+
+    if (action === Action.WAIT) {
+      if (this.version !== '20250124') {
+        throw new ToolError(`${action} is only available in version 20250124`);
+      }
+      await new Promise(resolve => setTimeout(resolve, duration! * 1000));
+      return await this.screenshot();
+    }
+
+    if (this.mouseActions.has(action)) {
+      if (!coordinate) {
+        throw new ToolError(`coordinate is required for ${action}`);
+      }
+      return await this.handleMouseAction(action, coordinate);
+    }
+
+    if (this.keyboardActions.has(action)) {
+      if (!text) {
+        throw new ToolError(`text is required for ${action}`);
+      }
+      return await this.handleKeyboardAction(action, text, duration);
+    }
+
+    throw new ToolError(`Invalid action: ${action}`);
+  }
+}
+
+// For backward compatibility
+export class ComputerTool20241022 extends ComputerTool {
+  constructor(page: Page) {
+    super(page, '20241022');
+  }
+}
+
+export class ComputerTool20250124 extends ComputerTool {
+  constructor(page: Page) {
+    super(page, '20250124');
+  }
+}

--- a/tools/types/computer.ts
+++ b/tools/types/computer.ts
@@ -1,0 +1,64 @@
+export enum Action {
+  // Mouse actions
+  MOUSE_MOVE = 'mouse_move',
+  LEFT_CLICK = 'left_click',
+  RIGHT_CLICK = 'right_click',
+  MIDDLE_CLICK = 'middle_click',
+  DOUBLE_CLICK = 'double_click',
+  TRIPLE_CLICK = 'triple_click',
+  LEFT_CLICK_DRAG = 'left_click_drag',
+  LEFT_MOUSE_DOWN = 'left_mouse_down',
+  LEFT_MOUSE_UP = 'left_mouse_up',
+
+  // Keyboard actions
+  KEY = 'key',
+  TYPE = 'type',
+  HOLD_KEY = 'hold_key',
+
+  // System actions
+  SCREENSHOT = 'screenshot',
+  CURSOR_POSITION = 'cursor_position',
+  SCROLL = 'scroll',
+  WAIT = 'wait',
+}
+
+// For backward compatibility
+export type Action_20241022 = Action;
+export type Action_20250124 = Action;
+
+export type MouseButton = 'left' | 'right' | 'middle';
+export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
+export type Coordinate = [number, number];
+export type Duration = number;
+
+export interface ActionParams {
+  action: Action;
+  text?: string;
+  coordinate?: Coordinate;
+  scrollDirection?: ScrollDirection;
+  scroll_amount?: number;
+  scrollAmount?: number;
+  duration?: Duration;
+  key?: string;
+  [key: string]: Action | string | Coordinate | ScrollDirection | number | Duration | undefined;
+}
+
+export interface ToolResult {
+  output?: string;
+  error?: string;
+  base64Image?: string;
+  system?: string;
+}
+
+export interface BaseAnthropicTool {
+  name: string;
+  apiType: string;
+  toParams(): ActionParams;
+}
+
+export class ToolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolError';
+  }
+} 

--- a/tools/utils/keyboard.ts
+++ b/tools/utils/keyboard.ts
@@ -1,0 +1,82 @@
+export class KeyboardUtils {
+  // Only map alternative names to standard Playwright modifier keys
+  private static readonly modifierKeyMap: Record<string, string> = {
+    'ctrl': 'Control',
+    'alt': 'Alt',
+    'command': 'Meta',
+    'win': 'Meta',
+  };
+
+  // Essential key mappings for Playwright compatibility
+  private static readonly keyMap: Record<string, string> = {
+    'return': 'Enter',
+    'space': ' ',
+    'left': 'ArrowLeft',
+    'right': 'ArrowRight',
+    'up': 'ArrowUp',
+    'down': 'ArrowDown',
+    'home': 'Home',
+    'end': 'End',
+    'pageup': 'PageUp',
+    'pagedown': 'PageDown',
+    'delete': 'Delete',
+    'backspace': 'Backspace',
+    'tab': 'Tab',
+    'esc': 'Escape',
+    'escape': 'Escape',
+    'insert': 'Insert',
+    'super_l': 'Meta',
+    'f1': 'F1',
+    'f2': 'F2',
+    'f3': 'F3',
+    'f4': 'F4',
+    'f5': 'F5',
+    'f6': 'F6',
+    'f7': 'F7',
+    'f8': 'F8',
+    'f9': 'F9',
+    'f10': 'F10',
+    'f11': 'F11',
+    'f12': 'F12',
+  };
+
+  static isModifierKey(key: string | undefined): boolean {
+    if (!key) return false;
+    const normalizedKey = this.modifierKeyMap[key.toLowerCase()] || key;
+    return ['Control', 'Alt', 'Shift', 'Meta'].includes(normalizedKey);
+  }
+
+  static getPlaywrightKey(key: string | undefined): string {
+    if (!key) {
+      throw new Error('Key cannot be undefined');
+    }
+
+    const normalizedKey = key.toLowerCase();
+
+    // Handle special cases
+    if (normalizedKey in this.keyMap) {
+      return this.keyMap[normalizedKey] as string;
+    }
+
+    // Normalize modifier keys
+    if (normalizedKey in this.modifierKeyMap) {
+      return this.modifierKeyMap[normalizedKey] as string;
+    }
+
+    // Return the key as is - Playwright handles standard key names
+    return key;
+  }
+
+  static parseKeyCombination(combo: string): string[] {
+    if (!combo) {
+      throw new Error('Key combination cannot be empty');
+    }
+    return combo.toLowerCase().split('+').map(key => {
+      const trimmedKey = key.trim();
+      if (!trimmedKey) {
+        throw new Error('Invalid key combination: empty key');
+      }
+      return this.getPlaywrightKey(trimmedKey);
+    });
+  }
+} 

--- a/tools/utils/validator.ts
+++ b/tools/utils/validator.ts
@@ -1,0 +1,67 @@
+import { Action, ToolError } from '../types/computer';
+import type { ActionParams, Coordinate, Duration } from '../types/computer';
+
+export class ActionValidator {
+  static validateText(text: string | undefined, required: boolean, action: string): void {
+    if (required && text === undefined) {
+      throw new ToolError(`text is required for ${action}`);
+    }
+    if (text !== undefined && typeof text !== 'string') {
+      throw new ToolError(`${text} must be a string`);
+    }
+  }
+
+  static validateCoordinate(coordinate: Coordinate | undefined, required: boolean, action: string): void {
+    if (required && !coordinate) {
+      throw new ToolError(`coordinate is required for ${action}`);
+    }
+    if (coordinate) {
+      this.validateAndGetCoordinates(coordinate);
+    }
+  }
+
+  static validateDuration(duration: Duration | undefined): void {
+    if (duration === undefined || typeof duration !== 'number') {
+      throw new ToolError(`${duration} must be a number`);
+    }
+    if (duration < 0) {
+      throw new ToolError(`${duration} must be non-negative`);
+    }
+    if (duration > 100) {
+      throw new ToolError(`${duration} is too long`);
+    }
+  }
+
+  static validateAndGetCoordinates(coordinate: Coordinate): Coordinate {
+    if (!Array.isArray(coordinate) || coordinate.length !== 2) {
+      throw new ToolError(`${coordinate} must be a tuple of length 2`);
+    }
+    if (!coordinate.every(i => typeof i === 'number' && i >= 0)) {
+      throw new ToolError(`${coordinate} must be a tuple of non-negative numbers`);
+    }
+    return coordinate;
+  }
+
+  static validateActionParams(params: ActionParams, mouseActions: Set<Action>, keyboardActions: Set<Action>): void {
+    const { action, text, coordinate, duration } = params;
+
+    // Validate text parameter
+    if (keyboardActions.has(action)) {
+      this.validateText(text, true, action);
+    } else {
+      this.validateText(text, false, action);
+    }
+
+    // Validate coordinate parameter
+    if (mouseActions.has(action)) {
+      this.validateCoordinate(coordinate, true, action);
+    } else {
+      this.validateCoordinate(coordinate, false, action);
+    }
+
+    // Validate duration parameter
+    if (action === Action.HOLD_KEY || action === Action.WAIT) {
+      this.validateDuration(duration);
+    }
+  }
+} 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}
+  

--- a/types/beta.ts
+++ b/types/beta.ts
@@ -1,0 +1,58 @@
+import type { BetaMessageParam as AnthropicMessageParam, BetaMessage as AnthropicMessage, BetaContentBlock as AnthropicContentBlock } from '@anthropic-ai/sdk/resources/beta/messages/messages';
+import type { ActionParams } from '../tools/types/computer';
+
+// Re-export the SDK types
+export type BetaMessageParam = AnthropicMessageParam;
+export type BetaMessage = AnthropicMessage;
+export type BetaContentBlock = AnthropicContentBlock;
+
+// Keep our local types for internal use
+export interface BetaTextBlock {
+  type: 'text';
+  text: string;
+  id?: string;
+  cache_control?: { type: 'ephemeral' };
+}
+
+export interface BetaImageBlock {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: 'image/png';
+    data: string;
+  };
+  id?: string;
+  cache_control?: { type: 'ephemeral' };
+}
+
+export interface BetaToolUseBlock {
+  type: 'tool_use';
+  name: string;
+  input: ActionParams;
+  id?: string;
+  cache_control?: { type: 'ephemeral' };
+}
+
+export interface BetaThinkingBlock {
+  type: 'thinking';
+  thinking: {
+    type: 'enabled';
+    budget_tokens: number;
+  } | {
+    type: 'disabled';
+  };
+  signature?: string;
+  id?: string;
+  cache_control?: { type: 'ephemeral' };
+}
+
+export interface BetaToolResultBlock {
+  type: 'tool_result';
+  content: (BetaTextBlock | BetaImageBlock)[] | string;
+  tool_use_id: string;
+  is_error: boolean;
+  id?: string;
+  cache_control?: { type: 'ephemeral' };
+}
+
+export type BetaLocalContentBlock = BetaTextBlock | BetaImageBlock | BetaToolUseBlock | BetaThinkingBlock | BetaToolResultBlock; 

--- a/utils/message-processing.ts
+++ b/utils/message-processing.ts
@@ -1,0 +1,79 @@
+import type { BetaMessage, BetaMessageParam, BetaToolResultBlock, BetaContentBlock, BetaLocalContentBlock } from '../types/beta';
+
+export function responseToParams(response: BetaMessage): BetaContentBlock[] {
+  return response.content.map(block => {
+    if (block.type === 'text' && block.text) {
+      return { type: 'text', text: block.text };
+    }
+    if (block.type === 'thinking') {
+      const { thinking, signature, ...rest } = block;
+      return { ...rest, thinking, ...(signature && { signature }) };
+    }
+    return block as BetaContentBlock;
+  });
+}
+
+export function maybeFilterToNMostRecentImages(
+  messages: BetaMessageParam[],
+  imagesToKeep: number,
+  minRemovalThreshold: number
+): void {
+  if (!imagesToKeep) return;
+
+  const toolResultBlocks = messages
+    .flatMap(message => Array.isArray(message?.content) ? message.content : [])
+    .filter((item): item is BetaToolResultBlock => 
+      typeof item === 'object' && item.type === 'tool_result'
+    );
+
+  const totalImages = toolResultBlocks.reduce((count, toolResult) => {
+    if (!Array.isArray(toolResult.content)) return count;
+    return count + toolResult.content.filter(
+      content => typeof content === 'object' && content.type === 'image'
+    ).length;
+  }, 0);
+
+  let imagesToRemove = Math.floor((totalImages - imagesToKeep) / minRemovalThreshold) * minRemovalThreshold;
+
+  for (const toolResult of toolResultBlocks) {
+    if (Array.isArray(toolResult.content)) {
+      toolResult.content = toolResult.content.filter(content => {
+        if (typeof content === 'object' && content.type === 'image') {
+          if (imagesToRemove > 0) {
+            imagesToRemove--;
+            return false;
+          }
+        }
+        return true;
+      });
+    }
+  }
+}
+
+const PROMPT_CACHING_BETA_FLAG = 'prompt-caching-2024-07-31';
+
+export function injectPromptCaching(messages: BetaMessageParam[]): void {
+  let breakpointsRemaining = 3;
+  
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message) continue;
+    if (message.role === 'user' && Array.isArray(message.content)) {
+      if (breakpointsRemaining > 0) {
+        breakpointsRemaining--;
+        const lastContent = message.content[message.content.length - 1];
+        if (lastContent) {
+          (lastContent as BetaLocalContentBlock).cache_control = { type: 'ephemeral' };
+        }
+      } else {
+        const lastContent = message.content[message.content.length - 1];
+        if (lastContent) {
+          delete (lastContent as BetaLocalContentBlock).cache_control;
+        }
+        break;
+      }
+    }
+  }
+}
+
+export { PROMPT_CACHING_BETA_FLAG }; 

--- a/utils/tool-results.ts
+++ b/utils/tool-results.ts
@@ -1,0 +1,49 @@
+import type { ToolResult } from '../tools/types/computer';
+import type { BetaToolResultBlock, BetaTextBlock, BetaImageBlock } from '../types/beta';
+
+export function makeApiToolResult(
+  result: ToolResult,
+  toolUseId: string
+): BetaToolResultBlock {
+  const toolResultContent: (BetaTextBlock | BetaImageBlock)[] = [];
+  let isError = false;
+
+  if (result.error) {
+    isError = true;
+    toolResultContent.push({
+      type: 'text',
+      text: maybePrependSystemToolResult(result, result.error),
+    });
+  } else {
+    if (result.output) {
+      toolResultContent.push({
+        type: 'text',
+        text: maybePrependSystemToolResult(result, result.output),
+      });
+    }
+    if (result.base64Image) {
+      toolResultContent.push({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: result.base64Image,
+        },
+      });
+    }
+  }
+
+  return {
+    type: 'tool_result',
+    content: toolResultContent,
+    tool_use_id: toolUseId,
+    is_error: isError,
+  };
+}
+
+export function maybePrependSystemToolResult(result: ToolResult, resultText: string): string {
+  if (result.system) {
+    return `<system>${result.system}</system>\n${resultText}`;
+  }
+  return resultText;
+} 


### PR DESCRIPTION
This PR extracts the Anthropic Computer Use functionality from create-kernel-app into a standalone SDK that can be used with any Playwright setup. This includes the same main changes from [onkernel/create-kernel-app#29](https://github.com/onkernel/create-kernel-app/pull/29) but excludes the custom Playwright tool implementation so review is easier.


### Key Changes:

**Core SDK:**
- **`index.ts`**: rewritten to export only `samplingLoop` function and essential types, removing OnKernel-specific dependencies
- **`example.ts`**: Added usage example showing how to integrate the SDK with Playwright
- **`README.md`**: Created comprehensive documentation with installation, usage, and API reference


