### PR TITLE
feat: upgrade agent with playwright tool

### DIFF
--- a/tools/computer.ts
+++ b/tools/computer.ts
@@ -1,12 +1,13 @@
 import type { Page } from 'playwright';
-import { Action, ToolError } from './types/computer';
-import type { ActionParams, BaseAnthropicTool, ToolResult } from './types/computer';
+import { Action } from './types/computer';
+import type { BaseComputerTool, ComputerActionParams } from './types/computer';
 import { KeyboardUtils } from './utils/keyboard';
 import { ActionValidator } from './utils/validator';
+import { ToolError, type ComputerToolDef, type ToolResult } from './types/base';
 
 const TYPING_DELAY_MS = 12;
 
-export class ComputerTool implements BaseAnthropicTool {
+export class ComputerTool implements BaseComputerTool {
   name: 'computer' = 'computer';
   protected page: Page;
   protected _screenshotDelay = 2.0;
@@ -46,7 +47,7 @@ export class ComputerTool implements BaseAnthropicTool {
     return this.version === '20241022' ? 'computer_20241022' : 'computer_20250124';
   }
 
-  toParams(): ActionParams {
+  toParams(): ComputerToolDef{
     const params = {
       name: this.name,
       type: this.apiType,
@@ -136,7 +137,7 @@ export class ComputerTool implements BaseAnthropicTool {
     }
   }
 
-  async call(params: ActionParams): Promise<ToolResult> {
+  async call(params: ComputerActionParams): Promise<ToolResult> {
     const { 
       action, 
       text, 
@@ -174,7 +175,7 @@ export class ComputerTool implements BaseAnthropicTool {
         throw new ToolError(`${action} is only available in version 20250124`);
       }
 
-      const scrollDirection = scrollDirectionParam || kwargs.scroll_direction;
+      const scrollDirection = scrollDirectionParam || kwargs.scroll_direction as string;
       const scrollAmountValue = scrollAmount || scroll_amount;
 
       if (!scrollDirection || !['up', 'down', 'left', 'right'].includes(scrollDirection)) {

--- a/tools/playwright.ts
+++ b/tools/playwright.ts
@@ -1,0 +1,115 @@
+import type { Page } from 'playwright';
+import { ToolError, type ToolResult, type ComputerUseTool, type FunctionToolDef, type ActionParams } from './types/base';
+
+// Supported Playwright methods - initially only goto
+const SUPPORTED_METHODS = ['goto'] as const;
+type SupportedMethod = typeof SUPPORTED_METHODS[number];
+
+export type PlaywrightActionParams = ActionParams & {
+  method: string;
+  args: string[];
+}
+
+export class PlaywrightTool implements ComputerUseTool {
+  name: 'playwright' = 'playwright';
+  protected page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  toParams(): FunctionToolDef {
+    return {
+      name: this.name,
+      type: 'custom',
+      input_schema: {
+        type: 'object',
+        properties: {
+          method: {
+            type: 'string',
+            description: 'The playwright function to call.',
+            enum: SUPPORTED_METHODS,
+          },
+          args: {
+            type: 'array',
+            description: 'The required arguments',
+            items: {
+              type: 'string',
+              description: 'The argument to pass to the function',
+            },
+          },
+        },
+        required: ['method', 'args'],
+      },
+    };
+  }
+
+  private validateMethod(method: string): method is SupportedMethod {
+    return SUPPORTED_METHODS.includes(method as SupportedMethod);
+  }
+
+  private async executeGoto(args: string[]): Promise<ToolResult> {
+    if (args.length !== 1) {
+      throw new ToolError('goto method requires exactly one argument: the URL');
+    }
+
+    const url = args[0];
+    if (!url || typeof url !== 'string') {
+      throw new ToolError('URL must be a non-empty string');
+    }
+
+    // Normalize URL - handles both full URLs and bare hostnames
+    let normalizedURL: string;
+    try {
+      const urlObj = new URL(url);
+      normalizedURL = urlObj.href;
+    } catch {
+      try {
+        const urlObj = new URL(`https://${url}`);
+        normalizedURL = urlObj.href;
+      } catch {
+        throw new ToolError(`Invalid URL format: ${url}`);
+      }
+    }
+
+    try {
+      await this.page.goto(normalizedURL, { 
+        waitUntil: 'networkidle',
+        timeout: 30000 
+      });
+      
+      // Wait a bit for the page to fully load
+      await this.page.waitForTimeout(1000);
+      
+      const currentURL = this.page.url();
+      const title = await this.page.title();
+      
+      return {
+        output: `Successfully navigated to ${currentURL}. Page title: "${title}"`,
+      };
+    } catch (error) {
+      throw new ToolError(`Failed to navigate to ${normalizedURL}: ${error}`);
+    }
+  }
+
+  async call(params: PlaywrightActionParams): Promise<ToolResult> {
+    const { method, args } = params as PlaywrightActionParams;
+
+    if (!this.validateMethod(method)) {
+      throw new ToolError(
+        `Unsupported method: ${method}. Supported methods: ${SUPPORTED_METHODS.join(', ')}`
+      );
+    }
+
+    if (!Array.isArray(args)) {
+      throw new ToolError('args must be an array');
+    }
+
+    switch (method) {
+      case 'goto':
+        return await this.executeGoto(args);
+      default:
+        throw new ToolError(`Method ${method} is not implemented`);
+    }
+  }
+}

--- a/tools/types/base.ts
+++ b/tools/types/base.ts
@@ -1,0 +1,50 @@
+export type ActionParams = Record<string, unknown>;
+
+export interface ToolResult {
+  output?: string;
+  error?: string;
+  base64Image?: string;
+  system?: string;
+}
+
+export class ToolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolError';
+  }
+} 
+
+// Standard function tool definition for custom tools like Playwright
+export interface FunctionToolDef {
+  name: string;
+  type: 'custom';
+  input_schema: {
+    type: 'object';
+    properties: Record<string, {
+      type: string;
+      description: string;
+      enum?: readonly string[];
+      items?: { type: string; description: string };
+    }>;
+    required?: string[];
+  };
+}
+
+// Computer tool definition (matches Anthropic's built-in computer tool format)
+export interface ComputerToolDef {
+  name: string;
+  type: 'computer_20241022' | 'computer_20250124';
+  display_width_px: number;
+  display_height_px: number;
+  display_number: null;
+}
+
+// Union type for all possible tool definitions
+export type ComputerUseToolDef = ComputerToolDef | FunctionToolDef;
+
+// Simple base interface for all tools
+export interface ComputerUseTool {
+  name: string;
+  toParams(): ComputerUseToolDef;
+  call(params: Record<string, unknown>): Promise<ToolResult>;
+}

--- a/tools/types/computer.ts
+++ b/tools/types/computer.ts
@@ -1,3 +1,5 @@
+import type { ActionParams, ComputerToolDef, ComputerUseTool, ToolResult } from "./base";
+
 export enum Action {
   // Mouse actions
   MOUSE_MOVE = 'mouse_move',
@@ -31,8 +33,7 @@ export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 export type Coordinate = [number, number];
 export type Duration = number;
 
-export interface ActionParams {
-  action: Action;
+export type ComputerActionParams =  ActionParams & {  action: Action;
   text?: string;
   coordinate?: Coordinate;
   scrollDirection?: ScrollDirection;
@@ -43,22 +44,9 @@ export interface ActionParams {
   [key: string]: Action | string | Coordinate | ScrollDirection | number | Duration | undefined;
 }
 
-export interface ToolResult {
-  output?: string;
-  error?: string;
-  base64Image?: string;
-  system?: string;
-}
-
-export interface BaseAnthropicTool {
+export interface BaseComputerTool extends ComputerUseTool {
   name: string;
   apiType: string;
-  toParams(): ActionParams;
+  toParams(): ComputerToolDef;
+  call(params: ComputerActionParams): Promise<ToolResult>;
 }
-
-export class ToolError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ToolError';
-  }
-} 

--- a/tools/utils/validator.ts
+++ b/tools/utils/validator.ts
@@ -1,5 +1,6 @@
-import { Action, ToolError } from '../types/computer';
-import type { ActionParams, Coordinate, Duration } from '../types/computer';
+import { ToolError, type ActionParams } from '../types/base';
+import { Action } from '../types/computer';
+import type { Coordinate, Duration } from '../types/computer';
 
 export class ActionValidator {
   static validateText(text: string | undefined, required: boolean, action: string): void {

--- a/types/base.ts
+++ b/types/base.ts
@@ -1,0 +1,50 @@
+export type ActionParams = Record<string, unknown>;
+
+export interface ToolResult {
+  output?: string;
+  error?: string;
+  base64Image?: string;
+  system?: string;
+}
+
+export class ToolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolError';
+  }
+} 
+
+// Standard function tool definition for custom tools like Playwright
+export interface FunctionToolDef {
+  name: string;
+  type: 'custom';
+  input_schema: {
+    type: 'object';
+    properties: Record<string, {
+      type: string;
+      description: string;
+      enum?: readonly string[];
+      items?: { type: string; description: string };
+    }>;
+    required?: string[];
+  };
+}
+
+// Computer tool definition (matches Anthropic's built-in computer tool format)
+export interface ComputerToolDef {
+  name: string;
+  type: 'computer_20241022' | 'computer_20250124';
+  display_width_px: number;
+  display_height_px: number;
+  display_number: null;
+}
+
+// Union type for all possible tool definitions
+export type ComputerUseToolDef = ComputerToolDef | FunctionToolDef;
+
+// Simple base interface for all tools
+export interface ComputerUseTool {
+  name: string;
+  toParams(): ComputerUseToolDef;
+  call(params: Record<string, unknown>): Promise<ToolResult>;
+}


### PR DESCRIPTION
This pr is ported from https://github.com/onkernel/create-kernel-app/pull/29 

The general idea is to provide playwright functionality to the agent for direct access to methods like `goto` for url changes etc due to limitations of the screenshot + keyboard combination approach.

Providing playwright access through tool calling is also generally a great idea as we can provide direct access to functions without waiting for the agent to figure it out. For example it will take agent 3 tool calls to figure out how to change url vs 1 step with the tool calling.

This pr also provides an entry point for ambiguous requests through google with system prompt upgrade.

Test with below code where we no longer need to directly navigate to a url first

```
  const browser = await chromium.launch({ headless: false });
  const page = await browser.newPage();

    const agent = new ComputerUseAgent({
      apiKey: ANTHROPIC_API_KEY,
      page,
    });
    
    // Define schema for a single story
    const HackerNewsStory = z.object({
      title: z.string(),
      points: z.number(),
      author: z.string(),
      comments: z.number(),
      url: z.string().optional(),
    });
    
    // Get multiple stories with structured data
    const stories = await agent.execute(
      'Get the first 5 posts on the first page on hackernews',
      z.array(HackerNewsStory).max(5)
    );
    console.log('Structured stories:', JSON.stringify(stories, null, 2));

```